### PR TITLE
Fix gate-kuryr-libnetwork-python35-nv error in kuryr-libnetwork

### DIFF
--- a/kuryr/lib/config.py
+++ b/kuryr/lib/config.py
@@ -20,7 +20,7 @@ from oslo_config import cfg
 from oslo_log import log
 
 from kuryr.lib._i18n import _
-import version
+import kuryr.lib.version
 
 
 core_opts = [

--- a/kuryr/lib/config.py
+++ b/kuryr/lib/config.py
@@ -19,7 +19,7 @@ import os
 from oslo_config import cfg
 from oslo_log import log
 
-from _i18n import _
+from kuryr.lib._i18n import _
 import version
 
 


### PR DESCRIPTION
This patch fix the gate-kuryr-libnetwork-python35-nv error, you can check here:
https://review.openstack.org/#/c/342664/2
